### PR TITLE
Add configurable support for unvalidated SSL certificates

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,11 @@ Create YAML file in your $HOME: ~/.wdmc.yml
 url: http://192.168.0.10
 username: admin
 password: super-secure-password
+validate_cert: true | false (default: true)
 ```
+If *validate_cert* is _true_ or unset, then the connection will fail if
+an HTTPS URL is specified and the server certificate is not valid.
+
 I gave admin permission to my user account:
 
 ```shell

--- a/lib/wdmc/client.rb
+++ b/lib/wdmc/client.rb
@@ -211,6 +211,7 @@ module Wdmc
     end
 
     def execute_request(args, &block)
+      args[:verify_ssl] = @config['validate_cert'].nil? ? true : @config['validate_cert']
       RestClient::Request.execute(args, &block)
     end
 

--- a/lib/wdmc/client.rb
+++ b/lib/wdmc/client.rb
@@ -16,7 +16,7 @@ module Wdmc
       @url = @config['url']
       @username = @config['username']
       @password = @config['password']
-      api = RestClient.get("#{@url}/api/2.1/rest/local_login?username=#{@username}&password=#{@password}")
+      api = get("#{@url}/api/2.1/rest/local_login?username=#{@username}&password=#{@password}")
       cookie = api.cookies
       File.write(@cookiefile, api.cookies)
     end
@@ -29,41 +29,41 @@ module Wdmc
 
     # device
     def system_information
-      response = RestClient.get("#{@config['url']}/api/2.1/rest/system_information", {accept: :json, :cookies => cookies})
+      response = get("#{@config['url']}/api/2.1/rest/system_information", {accept: :json, :cookies => cookies})
       eval(response)[:system_information]
     end
 
     def system_state
-      response = RestClient.get("#{@config['url']}/api/2.1/rest/system_state", {accept: :json, :cookies => cookies})
+      response = get("#{@config['url']}/api/2.1/rest/system_state", {accept: :json, :cookies => cookies})
       eval(response)[:system_state]
     end
 
     def firmware
-      response = RestClient.get("#{@config['url']}/api/2.1/rest/firmware_info", {accept: :json, :cookies => cookies})
+      response = get("#{@config['url']}/api/2.1/rest/firmware_info", {accept: :json, :cookies => cookies})
       eval(response)[:firmware_info]
     end
 
     def device_description
-      response = RestClient.get("#{@config['url']}/api/2.1/rest/device_description", {accept: :json, :cookies => cookies})
+      response = get("#{@config['url']}/api/2.1/rest/device_description", {accept: :json, :cookies => cookies})
       JSON.parse(response)['device_description']
     end
 
     def network
-      response = RestClient.get("#{@config['url']}/api/2.1/rest/network_configuration", {accept: :json, :cookies => cookies})
+      response = get("#{@config['url']}/api/2.1/rest/network_configuration", {accept: :json, :cookies => cookies})
       eval(response)[:network_configuration]
       #JSON.parse(response)['network_configuration']
     end
 
     # storage
     def storage_usage
-      response = RestClient.get("#{@config['url']}/api/2.1/rest/storage_usage", {accept: :json, :cookies => cookies})
+      response = get("#{@config['url']}/api/2.1/rest/storage_usage", {accept: :json, :cookies => cookies})
       eval(response)[:storage_usage]
     end
 
     ## working with shares
     # get all shares
     def all_shares
-      response = RestClient.get("#{@config['url']}/api/2.1/rest/shares", {accept: :json, :cookies => cookies})
+      response = get("#{@config['url']}/api/2.1/rest/shares", {accept: :json, :cookies => cookies})
       JSON.parse(response)['shares']['share']
     end
 
@@ -87,43 +87,43 @@ module Wdmc
 
     # add new share
     def add_share( data )
-      response = RestClient.post("#{@config['url']}/api/2.1/rest/shares", data, {accept: :json, :cookies => cookies})
+      response = post("#{@config['url']}/api/2.1/rest/shares", data, {accept: :json, :cookies => cookies})
       return response.code
     end
 
     # modifies a share
     def modify_share( data )
-      response = RestClient.put("#{@config['url']}/api/2.1/rest/shares", data, {accept: :json, :cookies => cookies})
+      response = put("#{@config['url']}/api/2.1/rest/shares", data, {accept: :json, :cookies => cookies})
       return response.code
     end
 
     # delete a share
     def delete_share( name )
-      response = RestClient.delete("#{@config['url']}/api/2.1/rest/shares/#{name}", {accept: :json, :cookies => cookies})
+      response = delete("#{@config['url']}/api/2.1/rest/shares/#{name}", {accept: :json, :cookies => cookies})
       return response.code
     end
 
     ## working with ACL of a share
     # get the specified share access
     def get_acl( name )
-      response = RestClient.get("#{@config['url']}/api/2.1/rest/share_access/#{name}", {accept: :json, :cookies => cookies})
+      response = get("#{@config['url']}/api/2.1/rest/share_access/#{name}", {accept: :json, :cookies => cookies})
       JSON.parse(response)['share_access_list']
     end
 
     def set_acl( data )
-      response = RestClient.post("#{@config['url']}/api/2.1/rest/share_access", data, {accept: :json, :cookies => cookies})
+      response = post("#{@config['url']}/api/2.1/rest/share_access", data, {accept: :json, :cookies => cookies})
       return response.code
     end
 
     def modify_acl( data )
-      response = RestClient.put("#{@config['url']}/api/2.1/rest/share_access", data, {accept: :json, :cookies => cookies})
+      response = put("#{@config['url']}/api/2.1/rest/share_access", data, {accept: :json, :cookies => cookies})
       return response.code
     end
 
     def delete_acl( data )
       # well, I know the code below is not very pretty...
       # if someone knows how this shitty delete with rest-client will work
-      response = RestClient.delete("#{@config['url']}/api/2.1/rest/share_access?share_name=#{data['share_name']}&username=#{data['username']}", {accept: :json, :cookies => cookies})
+      response = delete("#{@config['url']}/api/2.1/rest/share_access?share_name=#{data['share_name']}&username=#{data['username']}", {accept: :json, :cookies => cookies})
       return response
     end
     ## ACL end
@@ -131,20 +131,20 @@ module Wdmc
     ## TimeMachine
     # Get TimeMachine Configuration
     def get_tm
-      response = RestClient.get("#{@config['url']}/api/2.1/rest/time_machine", {accept: :json, :cookies => cookies})
+      response = get("#{@config['url']}/api/2.1/rest/time_machine", {accept: :json, :cookies => cookies})
       eval(response)[:time_machine]
     end
 
     # Set TimeMachine Configuration
     def set_tm( data )
-      response = RestClient.put("#{@config['url']}/api/2.1/rest/time_machine", data, {accept: :json, :cookies => cookies})
+      response = put("#{@config['url']}/api/2.1/rest/time_machine", data, {accept: :json, :cookies => cookies})
       return response
     end
 
     ## Users
     # Get all users
     def all_users
-      response = RestClient.get("#{@config['url']}/api/2.1/rest/users", {accept: :json, :cookies => cookies})
+      response = get("#{@config['url']}/api/2.1/rest/users", {accept: :json, :cookies => cookies})
       eval(response)[:users][:user]
     end
 
@@ -168,19 +168,19 @@ module Wdmc
 
     # add new user
     def add_user( data )
-      response = RestClient.post("#{@config['url']}/api/2.1/rest/users", data, {accept: :json, :cookies => cookies})
+      response = post("#{@config['url']}/api/2.1/rest/users", data, {accept: :json, :cookies => cookies})
       return response.code
     end
 
     # update an existing user
     def update_user( name, data )
-      response = RestClient.put("#{@config['url']}/api/2.1/rest/users/#{name}", data, {accept: :json, :cookies => cookies})
+      response = put("#{@config['url']}/api/2.1/rest/users/#{name}", data, {accept: :json, :cookies => cookies})
       return response.code
     end
 
     # delete user
     def delete_user( name )
-      response = RestClient.delete("#{@config['url']}/api/2.1/rest/users/#{name}", {accept: :json, :cookies => cookies})
+      response = delete("#{@config['url']}/api/2.1/rest/users/#{name}", {accept: :json, :cookies => cookies})
       return response.code
     end
 
@@ -188,8 +188,26 @@ module Wdmc
 
     def volumes
       login
-      response = RestClient.get("#{@config['url']}/api/2.1/rest/volumes", {accept: :json, :cookies => cookies})
+      response = get("#{@config['url']}/api/2.1/rest/volumes", {accept: :json, :cookies => cookies})
       volumes = JSON.parse(response)['volumes']['volume']
+    end
+
+    private
+
+    def get(url, headers={}, &block)
+      RestClient.get(url, headers)
+    end
+
+    def post(url, payload, headers={}, &block)
+      RestClient.post(url, payload, headers, &block)
+    end
+
+    def put(url, payload, headers={}, &block)
+      RestClient.put(url, payload, headers, &block)
+    end
+
+    def delete(url, headers={}, &block)
+      RestClient.delete(url, headers, &block)
     end
 
   end

--- a/lib/wdmc/client.rb
+++ b/lib/wdmc/client.rb
@@ -195,19 +195,23 @@ module Wdmc
     private
 
     def get(url, headers={}, &block)
-      RestClient.get(url, headers)
+      execute_request(:method => :get, :url => url, :headers => headers, &block)
     end
 
     def post(url, payload, headers={}, &block)
-      RestClient.post(url, payload, headers, &block)
+      execute_request(:method => :post, :url => url, :payload => payload, :headers => headers, &block)
     end
 
     def put(url, payload, headers={}, &block)
-      RestClient.put(url, payload, headers, &block)
+      execute_request(:method => :put, :url => url, :payload => payload, :headers => headers, &block)
     end
 
     def delete(url, headers={}, &block)
-      RestClient.delete(url, headers, &block)
+      execute_request(:method => :delete, :url => url, :headers => headers, &block)
+    end
+
+    def execute_request(args, &block)
+      RestClient::Request.execute(args, &block)
     end
 
   end


### PR DESCRIPTION
Configuration option to turn off certificate verification and avoid related connection errors for HTTPS/SSL URLs when server does not have a valid certificated (e.g., self-signed).