### PR TITLE
Use JSON.parse() instead of eval()

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ url: http://192.168.0.10
 username: admin
 password: super-secure-password
 validate_cert: true | false | warn (optional, default: true)
+api_net_nl_bug: true | false (optional, default: false)
 ```
 The value of *validate_cert* is relevant only for HTTPS URLs:
   - If not specified or set to _true_, then an invalid certificate will
@@ -37,6 +38,9 @@ The value of *validate_cert* is relevant only for HTTPS URLs:
   - If set to _warn_, then an invalid certificate will cause a
   warning message to be emitted and for certificate validation to
   be deactivated for the remainder of the operation.
+
+Set _api_net_nl_bug_ to _true_ to avoid crashes caused by newline
+characters in DNS server data in the API response from your server.
 
 I gave admin permission to my user account:
 

--- a/lib/wdmc/client.rb
+++ b/lib/wdmc/client.rb
@@ -43,17 +43,17 @@ module Wdmc
     # device
     def system_information
       response = get("#{@config['url']}/api/2.1/rest/system_information", {accept: :json, :cookies => cookies})
-      eval(response)[:system_information]
+      JSON.parse(response, :symbolize_names => true)[:system_information]
     end
 
     def system_state
       response = get("#{@config['url']}/api/2.1/rest/system_state", {accept: :json, :cookies => cookies})
-      eval(response)[:system_state]
+      JSON.parse(response, :symbolize_names => true)[:system_state]
     end
 
     def firmware
       response = get("#{@config['url']}/api/2.1/rest/firmware_info", {accept: :json, :cookies => cookies})
-      eval(response)[:firmware_info]
+      JSON.parse(response, :symbolize_names => true)[:firmware_info]
     end
 
     def device_description
@@ -63,14 +63,13 @@ module Wdmc
 
     def network
       response = get("#{@config['url']}/api/2.1/rest/network_configuration", {accept: :json, :cookies => cookies})
-      eval(response)[:network_configuration]
-      #JSON.parse(response)['network_configuration']
+      JSON.parse(response, :symbolize_names => true)[:network_configuration]
     end
 
     # storage
     def storage_usage
       response = get("#{@config['url']}/api/2.1/rest/storage_usage", {accept: :json, :cookies => cookies})
-      eval(response)[:storage_usage]
+      JSON.parse(response, :symbolize_names => true)[:storage_usage]
     end
 
     ## working with shares
@@ -145,7 +144,7 @@ module Wdmc
     # Get TimeMachine Configuration
     def get_tm
       response = get("#{@config['url']}/api/2.1/rest/time_machine", {accept: :json, :cookies => cookies})
-      eval(response)[:time_machine]
+      JSON.parse(response, :symbolize_names => true)[:time_machine]
     end
 
     # Set TimeMachine Configuration
@@ -158,7 +157,7 @@ module Wdmc
     # Get all users
     def all_users
       response = get("#{@config['url']}/api/2.1/rest/users", {accept: :json, :cookies => cookies})
-      eval(response)[:users][:user]
+      JSON.parse(response, :symbolize_names => true)[:users][:user]
     end
 
     # find a user by name


### PR DESCRIPTION
Commit https://github.com/okleinschmidt/wdmc/commit/0291d472220c5389c4ebccaa22d73540717d0170 resolves issue #4, eliminating the use of _eval()_ to parse server JSON responses into Ruby objects.

During testing, I encountered an exception-producing bug for server responses for network configuration information (issue #5). Commit https://github.com/okleinschmidt/wdmc/commit/cda9e7cb9b6eae8cde202ae739d897443ed7bfd8 provides a configurable work-around and associated documentation changes for that bug. Additionally, if the work-around configuration option is not set, then a suggestion to configure the work-around will be emitted ahead of the exception message and traceback if an appropriate exception is thrown.