### PR TITLE
Issue 5 - remove previous DNS formatting work-around

### DIFF
--- a/lib/wdmc/device.rb
+++ b/lib/wdmc/device.rb
@@ -76,7 +76,7 @@ module Wdmc
       puts "\sMAC Address\t\t: ".color(:whitesmoke) + @system_information[:mac_address]
       puts "\sNetmask\t\t: ".color(:whitesmoke) + @network[:netmask]
       puts "\sGateway\t\t: ".color(:whitesmoke) + @network[:gateway]
-      puts "\sDNS Servers\t\t: ".color(:whitesmoke) + "#{@network[:dns0].strip}, #{@network[:dns1].strip}, #{@network[:dns2]}"
+      puts "\sDNS Servers\t\t: ".color(:whitesmoke) + "#{@network[:dns0]}, #{@network[:dns1]}, #{@network[:dns2]}"
     end
 
     desc 'state', 'Device state'

--- a/lib/wdmc/device.rb
+++ b/lib/wdmc/device.rb
@@ -76,7 +76,8 @@ module Wdmc
       puts "\sMAC Address\t\t: ".color(:whitesmoke) + @system_information[:mac_address]
       puts "\sNetmask\t\t: ".color(:whitesmoke) + @network[:netmask]
       puts "\sGateway\t\t: ".color(:whitesmoke) + @network[:gateway]
-      puts "\sDNS Servers\t\t: ".color(:whitesmoke) + "#{@network[:dns0]}, #{@network[:dns1]}, #{@network[:dns2]}"
+      puts "\sDNS Servers\t\t: ".color(:whitesmoke) +
+               [@network[:dns0], @network[:dns1], @network[:dns2]].reject(&:empty?).join(', ')
     end
 
     desc 'state', 'Device state'


### PR DESCRIPTION
- Commit https://github.com/okleinschmidt/wdmc/commit/48bb883d15a4d2a41b974aad103175627724421f takes out the old work-around, since we have the new work-around in place.
- Since I was touching that code, I also prettied up the DNS server info display by getting rid of the extra commas when less than three servers are configured.