### PR TITLE
Test support -- re-introduced

### DIFF
--- a/.rspec
+++ b/.rspec
@@ -1,0 +1,1 @@
+--require spec_helper

--- a/spec/client_spec.rb
+++ b/spec/client_spec.rb
@@ -1,0 +1,81 @@
+require 'rspec'
+require 'wdmc/client'
+
+describe Wdmc::Client do
+  subject { Wdmc::Client.new }
+
+  def self.hash_w_symbol_keys(*methods)
+    methods.each do |method|
+
+      describe "\##{method.join(', ')}" do
+        it 'should return a Hash of some kind' do
+          expect(subject.send(*method)).to be_a_kind_of(Hash)
+        end
+
+        it 'should return a Hash with keys that are symbols' do
+          expect(keys_from_hash_hierarchy(subject.send(*method))).to all(be_a(Symbol))
+        end
+      end
+
+    end
+  end
+
+  def self.array_of_hash_w_symbol_keys(*methods)
+    methods.each do |method|
+
+      describe "\##{method.join(', ')}" do
+        it 'should return a list of hashes of some kind' do
+          expect(subject.send(*method)).to be_a_kind_of(Array) .and(all(be_a_kind_of(Hash)))
+        end
+
+        it 'should return a Hash with keys that are symbols' do
+          subject.send(*method).each do |entry|
+            expect(keys_from_hash_hierarchy(entry)).to all(be_a(Symbol))
+          end
+        end
+      end
+
+    end
+  end
+
+  # each argument is a method and its arguments
+  hash_w_symbol_keys(
+      ['system_information'],
+      ['system_state'],
+      ['firmware'],
+      ['device_description'],
+      ['network'],
+      ['storage_usage'],
+      ['get_tm'],
+
+  )
+
+  array_of_hash_w_symbol_keys(
+      ['all_shares'],
+      ['all_users'],
+      ['volumes'],
+  )
+
+
+  describe '#get_acl (has special cases)' do
+    context 'with no arguments' do
+      it 'should throw ArgumentError exception' do
+        expect {subject.send('get_acl')}.to raise_error(ArgumentError)
+      end
+    end
+
+    context 'with a share that does NOT have ACLs as the first argument' do
+      it 'should return HTTP 404 not found' do
+        expect {subject.send('get_acl', share_no_acl)}.to raise_error(RestClient::Exception, /404/)
+      end
+    end
+
+    context 'with a share that does have an ACL as the first argument' do
+      # it 'should behave like other methods that return a hash with symbols as keys' do
+        hash_w_symbol_keys(['get_acl', share_w_acl])
+      # end
+    end
+
+  end
+
+end

--- a/spec/client_spec.rb
+++ b/spec/client_spec.rb
@@ -70,11 +70,11 @@ describe Wdmc::Client do
       end
     end
 
-    context 'with a share that does have an ACL as the first argument' do
-      # it 'should behave like other methods that return a hash with symbols as keys' do
-        hash_w_symbol_keys(['get_acl', share_w_acl])
-      # end
-    end
+    # context 'with a share that does have an ACL as the first argument' do
+    #   # it 'should behave like other methods that return a hash with symbols as keys' do
+    #     hash_w_symbol_keys(['get_acl', share_w_acl])
+    #   # end
+    # end
 
   end
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,0 +1,12 @@
+require 'rspec'
+require 'wdmc'
+
+def share_no_acl; '_'; end
+def share_w_acl; 'Users'; end
+
+def keys_from_hash_hierarchy(hierarchy)
+  hierarchy.each_with_object([]) do | (k, v), keys |
+    keys << k
+    keys.concat(keys_from_hash_hierarchy(v)) if v.is_a? Hash
+  end
+end

--- a/wdmc.gemspec
+++ b/wdmc.gemspec
@@ -33,4 +33,5 @@ Gem::Specification.new do |spec|
 
   spec.add_development_dependency "bundler", '~> 1.13', '>= 1.13.7'
   spec.add_development_dependency "rake", '~> 12.0', '>= 12.0.0'
+  spec.add_development_dependency "rspec"
 end


### PR DESCRIPTION
Re-introducing test support (see description from PR #9 below):
- Reverting the revert of PR #10.
- Add the missing *.rspec* file.
- Turn off problematic ACL test until a more elegant solution can be found.

Fixes #11.

NB: This PR is on the new *develop* branch, so that we can simultaneously keep *master* safe **and** avoid revert (or at least delay it).

---

Added RSpec-based test setup for the dev environment and created some initial tests for the public HTTP GET-based methods in the _Client_ class.

To run the tests from the project directory, try one of the following:
```shell
bundle exec rspec
```
or
```shell
bundle exec rspec --format doc
```