### PR TITLE
reinstate tests for 'get_acl' on a share with ACLs

### DIFF
--- a/spec/client_spec.rb
+++ b/spec/client_spec.rb
@@ -64,17 +64,16 @@ describe Wdmc::Client do
       end
     end
 
-    context 'with a share that does NOT have ACLs as the first argument' do
+    context 'with the name of a share that does NOT have ACLs' do
       it 'should return HTTP 404 not found' do
         expect {subject.send('get_acl', share_no_acl)}.to raise_error(RestClient::Exception, /404/)
       end
     end
 
-    # context 'with a share that does have an ACL as the first argument' do
-    #   # it 'should behave like other methods that return a hash with symbols as keys' do
-    #     hash_w_symbol_keys(['get_acl', share_w_acl])
-    #   # end
-    # end
+    context 'with the name of a share that DOES have an ACL',
+            :skip => (ENV['acl_share'] ? nil : 'reason: to enable this test, set ENV["acl_share"] to the name of a share that has ACLs') do
+        hash_w_symbol_keys(['get_acl', ENV['acl_share']])
+    end
 
   end
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -2,7 +2,6 @@ require 'rspec'
 require 'wdmc'
 
 def share_no_acl; '_'; end
-def share_w_acl; 'Users'; end
 
 def keys_from_hash_hierarchy(hierarchy)
   hierarchy.each_with_object([]) do | (k, v), keys |


### PR DESCRIPTION
The tests are enabled by the presence of the *acl_share* environment variable. If it is not
set, then the tests are skipped, in which case rspec provides an explanation of how to enable the tests.

This PR fixes the specific tests that lead to issue #11 (and completes its resolution) and provides the test coverage intended by PR #9.

## Enabled with the parameter on the Unix command line
You can specify the value of *acl_share* as part of the command line used to run the tests.
```
$ env acl_share=share0 bundle exec rspec spec/client_spec.rb
........................

Finished in 4.8 seconds (files took 0.4064 seconds to load)
24 examples, 0 failures
```

##  Enabled with the setting exported from the shell environment
You can set (and export) *acl_share* (only required once per session) in your shell
```
acl_share=share0
export acl_share
```
and then run the test command repeatedly without needing to specify *acl_share* each time.
```
$ bundle exec rspec spec/client_spec.rb
........................

Finished in 4.8 seconds (files took 0.4064 seconds to load)
24 examples, 0 failures
```

## Disabled
You can run with these tests disabled, in case you don't have a share with ACLs or just want to disable the tests for whatever reason.

If you previously exported *acl_share* from the shell environment, be sure to unset it (this needs to be done only once, unless you set/export it again):
```
unset acl_share
```
Run the test command without setting the environment variable (note the "reason:" text in the output).
```
$ bundle exec rspec spec/client_spec.rb
......................**

Pending: (Failures listed here are expected and do not affect your suite's status)

  1) Wdmc::Client#get_acl (has special cases) with the name of a share that DOES have an ACL #get_acl,  should return a Hash of some kind
     # reason: to enable this test, set ENV["acl_share"] to the name of a share that has ACLs
     # ./spec/client_spec.rb:11

  2) Wdmc::Client#get_acl (has special cases) with the name of a share that DOES have an ACL #get_acl,  should return a Hash with keys that are symbols
     # reason: to enable this test, set ENV["acl_share"] to the name of a share that has ACLs
     # ./spec/client_spec.rb:15


Finished in 3.9 seconds (files took 0.42692 seconds to load)
24 examples, 0 failures, 2 pending
```